### PR TITLE
brazilian portuguese translation added

### DIFF
--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -1,0 +1,10 @@
+pt-br:
+  label_history_tab_all: Todos
+  label_history_tab_activity: Atividade
+  label_history_tab_comments: Comentários
+  label_history_tab_private: Privado
+  label_history_time_spent: Tempo gasto
+  label_history_time_hours_on: horas em
+  label_history_time_logged_by: Reportado por %{author} à %{age}
+  label_history_tab_time: Registro de tempo
+  label_tabtime_questions: Perguntas


### PR DESCRIPTION
brazilian portuguese translation added;

it may be necessary to rename it to pt-BR.yml depending on your sysconfig (perhaps on mac machines?). I run redmine in a linux box (mostly RHEL based), and plugins with "pt-BR.yml" files are ignored and translations get confused. I don't know if this is a specific linux + redmine 2.x behaviour or because I've been using the same redmine codebase since 0.X (something) and upgrading, upgrading, upgrading ... anyway, it's there :)

cheers
