### PR TITLE
Changed Bulgarian translation of permission labels. Added "History: " at...

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -9,7 +9,7 @@ bg:
   label_history_tab_time: Използвано време
   label_tabtime_questions: Въпроси
   
-  permission_view_all: История: разглеждане на всичко
-  permission_view_comments: История: разглеждане на коментари
-  permission_view_activity: История: разглеждане на активността
+  permission_view_all: "История: разглеждане на всичко"
+  permission_view_comments: "История: разглеждане на коментари"
+  permission_view_activity: "История: разглеждане на активността"
   


### PR DESCRIPTION
... the beginning. This way these labels are distinguished among others in the administrative role permission panel.
