### PR TITLE
Fix not visible journal entries appearing in All and Activity tab

### DIFF
--- a/lib/issue_detailed_tabs_time_issues_helper_patch.rb
+++ b/lib/issue_detailed_tabs_time_issues_helper_patch.rb
@@ -98,9 +98,9 @@ module RedmineIssueDetailedTabsTimeIssuesHelperPatch
               c << authoring(journal.created_on, journal.user, :label => :label_updated_time_by)
             c << "</h4>"
           
-            if (journal.details.any?) && User.current.allowed_to?(:view_activity,@project,:global => true)
+            if (journal.visible_details.any?) && User.current.allowed_to?(:view_activity,@project,:global => true)
               c << "<ul class='details'>"
-                details_to_strings(journal.details).each do |string|
+                details_to_strings(journal.visible_details).each do |string|
                 c << "<li>" + string + "</li>"
                 end
               c << "</ul>"


### PR DESCRIPTION
If there is a journal enrty with a visible and a not visible detail then both details appear in the All and in the Activity tab. For example: user1 updates two fields, one is visible for user2 and other is not. This case both modification is visible in a single entry for user2.
