### PR TITLE
fixed issue with displaying when entry is journal and not visible Fixes #46

### DIFF
--- a/lib/issue_detailed_tabs_time_issues_helper_patch.rb
+++ b/lib/issue_detailed_tabs_time_issues_helper_patch.rb
@@ -81,6 +81,8 @@ module RedmineIssueDetailedTabsTimeIssuesHelperPatch
           draw_journal_in_tab(entry, index)
         elsif entry.is_a?(TimeEntry)
           draw_timelog_in_tab(entry, index)
+        else
+          ""
         end
         c
       end


### PR DESCRIPTION
On our instance of Redmine, we discovered a strange bug caused by entry visibility.
The reported error was:
Rendered plugins/redmine_resources/app/views/issues/show.html.erb within layouts/base (326.6ms)
Completed 500 Internal Server Error in 471.9ms

ActionView::Template::Error (can't convert nil into String):
23: </ul>
24: </div>
25:
26: <%= c = draw_entries_in_issue_history_tab(entries, journals).html_safe >
27: < end >
28: < heads_for_wiki_formatter if User.current.allowed_to?(:edit_issue_notes, issue.project) || User.current.allowed_to?(:edit_own_issue_notes, issue.project) %>
app/controllers/issues_controller.rb:128:in `block (2 levels) in show'
app/controllers/issues_controller.rb:125:in`show'

I've done a little digging and it resulted that in specific conditions, draw_entry_tab was returning a nil (the 2 if where both false)
Fixed by adding an empty string as a fallback.
