### PR TITLE
Fixed bug where linking to notes would not focus on the note

### DIFF
--- a/assets/javascripts/issue-history-tabs.js
+++ b/assets/javascripts/issue-history-tabs.js
@@ -24,44 +24,69 @@ function readCookie(name) {
 	return null;
 }
 
+HISTORY_TABS = {
+	'tabtime_questions': '.journal.question,.journal.question-closed',
+	'tabtime_time': '.journal.has-time',
+	'history_private': '.journal.private-notes',
+	'history_comments': '.journal.has-notes',
+	'history_activity': '.journal.has-details',
+	'history_all': '.journal',
+	'history_none': ''
+}
+
 function initTabs() {
-	bindTab('tabtime_questions', '.journal.question,.journal.question-closed');
-	bindTab('tabtime_time', '.journal.has-time');
-	bindTab('history_private', '.journal.private-notes');
-	bindTab('history_comments', '.journal.has-notes');
-	bindTab('history_activity', '.journal.has-details');
-	bindTab('history_all', '.journal');
-	bindTab('history_none', '');
+	for(tab in HISTORY_TABS) {
+		bindTab(tab)
+	}
 	selectDefaultTab();
 }
 
-function bindTab(tab, journal){
-	$('#tab-'+tab).click(function(){
-		$('.tab-history').removeClass('selected');
-		$('#tab-'+tab).addClass('selected');
-		if("replaceState" in window.history){
-			window.history.replaceState(null,document.title,'?tab='+tab);
+function bindTab(tab){
+	$('#tab-' + tab).click(function(){
+		selectTab(tab);
+		if('replaceState' in window.history){
+			window.history.replaceState(null, document.title, '?tab=' + tab);
 		}
-		$('.journal').hide();
-		$(journal).show();
-		createCookie('selected_issue_tab', tab);
 	});
+}
+
+function selectTab(tab) {
+	if(!(tab in HISTORY_TABS)) {
+		return;
+	}
+	$('.tab-history').removeClass('selected');
+	$('#tab-' + tab).addClass('selected');
+	$('.journal').hide();
+	$(HISTORY_TABS[tab]).show();
+	createCookie('selected_issue_tab', tab);
 }
 
 function selectDefaultTab() {
 	var tab = readCookie('selected_issue_tab');
-	if(tab != null) {
-		var elem = $('#tab-' + tab);
+	var focusOn = null;
+	if(window.location.hash != '') {
+		var elName = window.location.hash;
+		elName = elName.substring(1, elName.length);
+		var elem = $('a[name=' + elName + ']').parent().parent();
 		if(elem) {
-			elem.click();
-			return;
+			tab = 'history_all';
+			focusOn = elem;
 		}
 	}
-  var elem = $('.tab-history.selected').not('#tab-history_all')[0];
-  if(elem && (elem.click != undefined)) {
-    elem.click();
-  }
-	// $('.tab-history.selected').not('#tab-history_all')[0] && $('.tab-history.selected').not('#tab-history_all')[0].click();
+	if(!tab) {
+		var elem = $('.tab-history.selected').not('#tab-history_all')[0];
+		if(elem) {
+			var id = elem.attr('id');
+			tab = id.substring(4, id.length);
+		}
+	}
+	selectTab(tab);
+	if(focusOn) {
+		$('html, body').animate({
+			scrollTop: focusOn.offset().top
+		}, 500);
+		focusOn.addClass('focus');
+	}
 }
 
 $(document).ready(function(){

--- a/assets/javascripts/issue-history-tabs.js
+++ b/assets/javascripts/issue-history-tabs.js
@@ -57,7 +57,11 @@ function selectDefaultTab() {
 			return;
 		}
 	}
-	$('.tab-history.selected').not('#tab-history_all')[0] && $('.tab-history.selected').not('#tab-history_all')[0].click();
+  var elem = $('.tab-history.selected').not('#tab-history_all')[0];
+  if(elem && (elem.click != undefined)) {
+    elem.click();
+  }
+	// $('.tab-history.selected').not('#tab-history_all')[0] && $('.tab-history.selected').not('#tab-history_all')[0].click();
 }
 
 $(document).ready(function(){

--- a/assets/stylesheets/issue_history_tabs.css
+++ b/assets/stylesheets/issue_history_tabs.css
@@ -1,3 +1,12 @@
 #history > h3 {
     display: none;
 }
+
+.journal {
+  transition: background 2s;
+}
+
+.journal.focus {
+  background: #F5E5C9;
+  border: 1px solid #F2D096;
+}

--- a/init.rb
+++ b/init.rb
@@ -3,13 +3,13 @@ require 'issue_tabs_listener'
 require_dependency 'issue_detailed_tabs_time_issues_helper_patch'
 
 Redmine::Plugin.register :redmine_issue_detailed_tabs_time do
-  
+
   project_module :issue_tracking do
 	  permission :view_all, { :all => :index }
 	  permission :view_comments, { :all => :index }
 	  permission :view_activity, { :all => :index }
   end
-  
+
   name 'Redmine Issue Detailed Tabs & Time'
   author 'Mark Kalender'
   description 'This plugin provide breaks down issues comments into tabs, also adds a time log'


### PR DESCRIPTION
Previously when a url like `/issues/1234#note-4` was visited it would be immediately replaced with `/issues/1234?tab=history_all`, and the page would not focus on the note.

This change checks if there is a note in the url fragment and if there is, displays the 'all' tab, scrolls to and highlights the note.

Also refactored the `initTabs` function to make it easier to add more tabs and to select tabs by id rather than id+journal class